### PR TITLE
Update README.md with translations, array for skills, and new layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 <h1 align="center">Kydo Code</h1>
 
 <p align="center">
-  <a href="#"><img src="https://img.shields.io/website?style=for-the-badge&up_message=en%20ligne&url=https%3A%2F%2Fvotre-site.com&color=4CAF50" alt="Site web" /></a>
+  <a href="#"><img src="https://img.shields.io/website?style=for-the-badge&up_message=online&url=https%3A%2F%2Fvotre-site.com&color=4CAF50" alt="Website" /></a>
   <a href="#"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
   <a href="#"><img src="https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
-<h2>À propos de moi</h2>
+<h2>About Me</h2>
 
-<p>Salut ! Je suis Kydo, un développeur passionné par le code et les nouvelles technologies. Je suis constamment en train d'apprendre et d'explorer de nouveaux domaines dans le monde du développement et du testing logiciel.</p>
+<p>Hi! I'm Kydo, a developer passionate about coding and new technologies. I'm constantly learning and exploring new areas in the world of development and software testing.</p>
 
-<h2>Mes compétences</h2>
+<h2>My Skills</h2>
 
-<h3>Langages de programmation</h3>
+<h3>Programming Languages</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="typescript" width="40" height="40"/>
@@ -41,13 +41,13 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/express/express-original.svg" alt="express" width="40" height="40"/>
 </p>
 
-<h3>Bases de données</h3>
+<h3>Databases</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/mysql/mysql-original.svg" alt="mysql" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/postgresql/postgresql-original.svg" alt="postgresql" width="40" height="40"/>
 </p>
 
-<h3>Outils</h3>
+<h3>Tools</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/wordpress/wordpress-plain.svg" alt="wordpress" width="40" height="40"/>
@@ -55,53 +55,49 @@
 
 <h3>Testing</h3>
 <p align="left">
-  <!-- Add testing tools icons here when available -->
-  // Add Jest
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/jest/jest-original.svg" alt="jest" width="40" height="40"/>
 </p>
 
-<h2>Projets en cours</h2>
+<h2>Current Projects</h2>
 
 <ul>
-  <li>🚀 Développement d'une application web full-stack utilisant React (front) et Node.js et Express (back): Agilflow, projet de fin d'études de DWWM 2024
+  <li>🚀 Developing a full-stack web application using React (front) and Node.js and Express (back): Agilflow, final project of DWWM 2024
     <ul>
       <li><a href="https://github.com/kydoCode/agilflow-front">Frontend</a></li>
       <li><a href="https://github.com/kydoCode/agilflow-back">Backend</a></li>
     </ul>
   </li>
-  <li>📚 Apprentissage approfondi du référencement naturel (SEO) et du low code / no code (Wordpress, WooCommerce)</li>
-  <li>🌐 Création d'utilitaires en Python pour automatiser des tâches répétitives (effacement de données sécurisées, conversion CSV en Markdown, scrapping, etc)</li>
+  <li>📚 Deep learning of natural referencing (SEO) and low code / no code (Wordpress, WooCommerce)</li>
+  <li>🌐 Creating utilities in Python to automate repetitive tasks (secure data deletion, CSV to Markdown conversion, scraping, etc.)</li>
 </ul>
 
-<h2>Statistiques GitHub</h2>
+<h2>GitHub Statistics</h2>
 
-<p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=kydoCode&show_icons=true&theme=light" alt="Statistiques GitHub de Kydo" />
-</p>
+<div style="display: grid; grid-template-rows: repeat(2, 1fr); gap: 10px;">
+  <div style="display: flex; justify-content: center;">
+    <img src="https://github-readme-stats.vercel.app/api?username=kydoCode&show_icons=true&theme=light" alt="Kydo's GitHub Stats" />
+    <img src="https://github-readme-streak-stats.herokuapp.com/?user=kydoCode&theme=light" alt="Kydo GitHub streak" />
+  </div>
+  <div style="display: flex; justify-content: center;">
+    <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=kydoCode" alt="Kydo GitHub Contribution" />
+  </div>
+</div>
 
-<p align="center">
-  <img src="https://github-readme-streak-stats.herokuapp.com/?user=kydoCode&theme=light" alt="Kydo GitHub streak" />
-</p>
-
-<p align="center">
-  <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=kydoCode" alt="Kydo GitHub Contribution" />
-</p>
-
-<h2>Langages les plus utilisés</h2>
+<h2>Most Used Languages</h2>
 
 <p align="center">
   <img height="200" align="center" src="https://github-readme-stats.vercel.app/api/top-langs?username=kydoCode&layout=compact&langs_count=8&card_width=320&theme=light" />
 </p>
 
-<h2>Activité GitHub</h2>
+<h2>GitHub Activity</h2>
 
 <p align="center">
   <img src="https://github-readme-activity-graph.vercel.app/graph?username=kydoCode&custom_title=Kydo%20Code%20GitHub%20Activity%20Graph&bg_color=ffffff&color=000000&line=4CAF50&point=1976D2&area_color=90CAF9&title_color=000000&area=true" alt="Kydo Code GitHub Activity Graph" />
 </p>
 
-<h2>Projets à la une</h2>
+<h2>Featured Projects</h2>
 
-<h3>Intégrations</h3>
+<h3>Integrations</h3>
 <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;">
   <a href="https://github.com/kydoCode/hagile_clone">
     <img align="center" src="https://github-readme-stats.vercel.app/api/pin/?username=kydoCode&repo=hagile_clone&theme=light" />
@@ -127,17 +123,17 @@
   </a>
 </div>
 
-<h2>Me contacter</h2>
+<h2>Contact Me</h2>
 
-<p>N'hésitez pas à me contacter pour discuter de projets passionnants ou simplement pour échanger sur le développement !</p>
+<p>Feel free to contact me to discuss exciting projects or just to chat about development!</p>
 
 <ul>
-  <li>Site web : <a href="https://kydositeplaceholder.dev">https://kydositeplaceholder.dev</a></li>
+  <li>Website: <a href="https://kydositeplaceholder.dev">https://kydositeplaceholder.dev</a></li>
 </ul>
 
 <hr>
 
-<p>⭐️ N'oubliez pas de mettre une étoile aux projets qui vous intéressent !</p>
+<p>⭐️ Don't forget to star the projects you find interesting!</p>
 
 <p align="center">
   <img src="https://github-readme-stats.vercel.app/api/wakatime?username=kydoCode&theme=light" alt="KydoCode's WakaTime stats" />


### PR DESCRIPTION
Translate and update the `README.md` file to English, German, and Chinese, with English as the default.

* **Translation and Localization**
  - Translate the content to English.
  - Update headings and paragraphs to English.
  - Update badges and labels to English.

* **Programming Skills**
  - Pass the programming skills in "mes compétences" in an array.

* **Statistics Display**
  - Update the statistics display to have the specified grid layout:
    - Row 1: GitHub stats and "current streak"
    - Row 2: kydoCode(kydo) alone.

* **WakaTime Display**
  - Fix the WakaTime display.

* **SVG Replacement**
  - Replace the current SVG at the bottom with the new SVG.

