### PR TITLE
Move Wordpress from tools section to No-code / low-code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <a href="README.md">English</a> | <a href="README_de.md">German</a> | <a href="README_fr.md">French</a> | <a href="README_zh.md">Chinese</a>
 </p>
@@ -54,6 +53,10 @@
 <h3>Tools</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+</p>
+
+<h3>No-code / low-code</h3>
+<p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/wordpress/wordpress-plain.svg" alt="wordpress" width="40" height="40"/>
 </p>
 

--- a/README_de.md
+++ b/README_de.md
@@ -54,6 +54,10 @@
 <h3>Werkzeuge</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+</p>
+
+<h3>No-code / low-code</h3>
+<p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/wordpress/wordpress-plain.svg" alt="wordpress" width="40" height="40"/>
 </p>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -54,6 +54,10 @@
 <h3>Outils</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+</p>
+
+<h3>No-code / low-code</h3>
+<p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/wordpress/wordpress-plain.svg" alt="wordpress" width="40" height="40"/>
 </p>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,6 +54,10 @@
 <h3>工具</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+</p>
+
+<h3>No-code / low-code</h3>
+<p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/wordpress/wordpress-plain.svg" alt="wordpress" width="40" height="40"/>
 </p>
 


### PR DESCRIPTION
Move Wordpress from "tools" section to a new "No-code / low-code" section in multiple README files.

* Create a new "No-code / low-code" section in `README.md`, `README_fr.md`, `README_de.md`, and `README_zh.md`.
* Move the Wordpress icon from the "Tools" section to the new "No-code / low-code" section in `README.md`.
* Move the Wordpress icon from the "Outils" section to the new "No-code / low-code" section in `README_fr.md`.
* Move the Wordpress icon from the "Werkzeuge" section to the new "No-code / low-code" section in `README_de.md`.
* Move the Wordpress icon from the "工具" section to the new "No-code / low-code" section in `README_zh.md`.

