### PR TITLE
Fix broken SwiftUI and UIKit icon links using SVG and update GitHub banner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="README.md">English</a> | <a href="README_de.md">Deutsch</a> | <a href="README_fr.md">Français</a> | <a href="README_zh.md">中文</a>
 </p>
 <h1 align="center">
-  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -26,8 +26,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swiftui/swiftui-original.svg" alt="swiftui" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/uikit/uikit-original.svg" alt="uikit" width="40" height="40"/>
+  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
+  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>
@@ -55,6 +55,7 @@
 <h3>Tools</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/github/github-original.svg" alt="github" width="40" height="40"/>
 </p>
 
 <h3>No-code / low-code</h3>

--- a/README_de.md
+++ b/README_de.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swiftui/swiftui-original.svg" alt="swiftui" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/uikit/uikit-original.svg" alt="uikit" width="40" height="40"/>
+  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
+  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>
@@ -56,6 +56,7 @@
 <h3>Werkzeuge</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/github/github-original.svg" alt="github" width="40" height="40"/>
 </p>
 
 <h3>No-code / low-code</h3>

--- a/README_fr.md
+++ b/README_fr.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swiftui/swiftui-original.svg" alt="swiftui" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/uikit/uikit-original.svg" alt="uikit" width="40" height="40"/>
+  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
+  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>
@@ -56,6 +56,7 @@
 <h3>Outils</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/github/github-original.svg" alt="github" width="40" height="40"/>
 </p>
 
 <h3>No-code / low-code</h3>

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swiftui/swiftui-original.svg" alt="swiftui" width="40" height="40"/>
-  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/uikit/uikit-original.svg" alt="uikit" width="40" height="40"/>
+  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
+  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>前端</h3>
@@ -56,6 +56,7 @@
 <h3>工具</h3>
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg" alt="git" width="40" height="40"/>
+  <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/github/github-original.svg" alt="github" width="40" height="40"/>
 </p>
 
 <h3>无代码 / 低代码</h3>


### PR DESCRIPTION
Fix broken SwiftUI and UIKit icon links using SVGs in the `img` folder, remove `kydo_github_banner` from the root, and fix links in all README files.

* **README.md**
  - Update `kydo_github_banner` link to reference the image in the `img` folder.
  - Update SwiftUI and UIKit icon links to use the SVGs in the `img` folder.
  - Add GitHub to the tools section.
* **README_de.md**
  - Update `kydo_github_banner` link to reference the image in the `img` folder.
  - Update SwiftUI and UIKit icon links to use the SVGs in the `img` folder.
  - Add GitHub to the tools section.
* **README_fr.md**
  - Update `kydo_github_banner` link to reference the image in the `img` folder.
  - Update SwiftUI and UIKit icon links to use the SVGs in the `img` folder.
  - Add GitHub to the tools section.
* **README_zh.md**
  - Update `kydo_github_banner` link to reference the image in the `img` folder.
  - Update SwiftUI and UIKit icon links to use the SVGs in the `img` folder.
  - Add GitHub to the tools section.

