### PR TITLE
Update links for SwiftUI, UIKit, and kydo_github_banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="README.md">English</a> | <a href="README_de.md">Deutsch</a> | <a href="README_fr.md">Français</a> | <a href="README_zh.md">中文</a>
 </p>
 <h1 align="center">
-  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -26,8 +26,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
-  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="swiftui" width="40" height="40"/>
+  <img src="https://i.ibb.co/Z6PrfrD/uikit-logo.png" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>

--- a/README_de.md
+++ b/README_de.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
-  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="swiftui" width="40" height="40"/>
+  <img src="https://i.ibb.co/Z6PrfrD/uikit-logo.png" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>

--- a/README_fr.md
+++ b/README_fr.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
-  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="swiftui" width="40" height="40"/>
+  <img src="https://i.ibb.co/Z6PrfrD/uikit-logo.png" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>Front-end</h3>

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="img/kydo_github_banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>
@@ -27,8 +27,8 @@
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/swift/swift-original.svg" alt="swift" width="40" height="40"/>
-  <img src="img/swiftui-logo.svg" alt="swiftui" width="40" height="40"/>
-  <img src="img/uikit-logo.svg" alt="uikit" width="40" height="40"/>
+  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="swiftui" width="40" height="40"/>
+  <img src="https://i.ibb.co/Z6PrfrD/uikit-logo.png" alt="uikit" width="40" height="40"/>
 </p>
 
 <h3>前端</h3>


### PR DESCRIPTION
Update the links for SwiftUI and UIKit to use the previous i.ibb.co link for `kydo_github_banner`.

* **README.md**
  - Update the `img/kydo_github_banner.jpg` link to use the previous i.ibb.co link.
  - Update the `img/swiftui-logo.svg` link to use the previous i.ibb.co link.
  - Update the `img/uikit-logo.svg` link to use the previous i.ibb.co link.

* **README_de.md**
  - Update the `img/kydo_github_banner.jpg` link to use the previous i.ibb.co link.
  - Update the `img/swiftui-logo.svg` link to use the previous i.ibb.co link.
  - Update the `img/uikit-logo.svg` link to use the previous i.ibb.co link.

* **README_fr.md**
  - Update the `img/kydo_github_banner.jpg` link to use the previous i.ibb.co link.
  - Update the `img/swiftui-logo.svg` link to use the previous i.ibb.co link.
  - Update the `img/uikit-logo.svg` link to use the previous i.ibb.co link.

* **README_zh.md**
  - Update the `img/kydo_github_banner.jpg` link to use the previous i.ibb.co link.
  - Update the `img/swiftui-logo.svg` link to use the previous i.ibb.co link.
  - Update the `img/uikit-logo.svg` link to use the previous i.ibb.co link.

