### PR TITLE
Update Kydo GitHub banner links in all localized README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <a href="README.md">English</a> | <a href="README_de.md">Deutsch</a> | <a href="README_fr.md">Français</a> | <a href="README_zh.md">中文</a>
 </p>
 <h1 align="center">
-  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>

--- a/README_de.md
+++ b/README_de.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>

--- a/README_fr.md
+++ b/README_fr.md
@@ -144,7 +144,7 @@
 
 <hr>
 
-<p>⭐️ N'oubliez pas de mettre en étoile les projets que vous trouvez intéressants!</p>
+<p>⭐️ N'oubliez pas à mettre en étoile les projets que vous trouvez intéressants!</p>
 
 <p align="center">
   <img src="https://github-readme-stats.vercel.app/api/wakatime?username=kydoCode&theme=light" alt="Statistiques WakaTime de KydoCode" />

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">
-  <img src="https://i.ibb.co/YdY67cs/swiftui-96x96-2x.png" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
+  <img src="https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg" alt="Kydo Banner" width="100%" style="max-width: 800px; border-radius: 8px;" />
 </h1>
 
 <h1 align="center">Kydo Code</h1>


### PR DESCRIPTION
Update the Kydo GitHub banner link in `README_fr.md`.

* Change the `src` attribute of the `img` tag in the h1 tag to "https://i.ibb.co/8jS0PnZ/kydo-github-banner.jpg".